### PR TITLE
Add function "calculate_minor_cycle"

### DIFF
--- a/tertimuss/simulation_lib/system_definition/utils/__init__.py
+++ b/tertimuss/simulation_lib/system_definition/utils/__init__.py
@@ -6,5 +6,6 @@ System definition utilities
 Utilities to speed up the system definition
 """
 from ._tasks_specification import calculate_major_cycle
+from ._tasks_specification import calculate_minor_cycle
 from ._processor_specification import generate_default_cpu
 from ._environment_specification import default_environment_specification

--- a/tertimuss/simulation_lib/system_definition/utils/_tasks_specification.py
+++ b/tertimuss/simulation_lib/system_definition/utils/_tasks_specification.py
@@ -1,6 +1,9 @@
-from ...math_utils import list_float_lcm
+from ...math_utils import list_float_lcm, list_float_gcd
 from .._tasks_specification import TaskSet
 
 
 def calculate_major_cycle(task_set: TaskSet):
     return list_float_lcm([i.period for i in task_set.periodic_tasks])
+
+def calculate_minor_cycle(task_set: TaskSet):
+    return list_float_gcd([i.period for i in task_set.periodic_tasks])


### PR DESCRIPTION
Add a function named "calculate_minor_cycle" to the package
"tertimuss.simulation_lib.system_definition.utils", to calculate
the CE minor cycle using the gcd of the tasks periods
This function is analog to the existing "calculate_major_cycle"